### PR TITLE
Use less CI resources

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,6 @@
+env:
+  CIRRUS_CHANGE_MESSAGE: ""
+
 test_task:
   auto_cancellation: true
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,8 +2,6 @@ test_task:
   auto_cancellation: true
   container:
     image: gradle:jdk8
-    cpu: 8
-    memory: 24G
   setup_workspace_script: |
     chmod +x ./gradlew
     rm -rf $CIRRUS_WORKING_DIR/src/main/resources/build.txt


### PR DESCRIPTION
Gradle in this repository is not configured for parallel execution. Plus there is only one project so there is no benefit of using 8 cores. 🤷‍♂️